### PR TITLE
Add Author to manifest file

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,6 +3,7 @@
 
   "name": "Ugly HTTP",
   "description": "Makes HTTP pages conspicuous.",
+  "author": "Lucas Garron (@lgarron)",
   "version": "1.0.0",
   "icons": {
     "128": "images/extensionIcon-128px.png"


### PR DESCRIPTION
Microsoft Edge refuses to parse a manifest unless it contains an |author| element. This is the only issue that prevents the extension from loading in Edge.